### PR TITLE
update Dropwizard to 0.8.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <jetty.version>9.2.6.v20141205</jetty.version>
-        <dropwizard.version>0.8.0-rc3-SNAPSHOT</dropwizard.version>
+        <dropwizard.version>0.8.0-rc2</dropwizard.version>
     </properties>
 
     <dependencies>
@@ -43,13 +43,6 @@
             <groupId>io.dropwizard</groupId>
             <artifactId>dropwizard-servlets</artifactId>
             <version>${dropwizard.version}</version>
-        </dependency>
-
-        <dependency>
-            <groupId>org.eclipse.jetty</groupId>
-            <artifactId>jetty-servlet</artifactId>
-            <version>${jetty.version}</version>
-            <scope>test</scope>
         </dependency>
 
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -10,7 +10,7 @@
 
     <groupId>com.bazaarvoice.dropwizard</groupId>
     <artifactId>dropwizard-configurable-assets-bundle</artifactId>
-    <version>0.2.3-SNAPSHOT</version>
+    <version>0.3.0</version>
     <packaging>jar</packaging>
 
     <name>Dropwizard Configurable Asset Bundle</name>
@@ -28,8 +28,7 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jetty.version>9.2.6.v20141205</jetty.version>
-        <dropwizard.version>0.8.0-rc2</dropwizard.version>
+        <dropwizard.version>0.8.0</dropwizard.version>
     </properties>
 
     <dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -28,16 +28,11 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <jetty.version>9.0.7.v20131107</jetty.version>
-        <dropwizard.version>0.7.1</dropwizard.version>
+        <jetty.version>9.2.6.v20141205</jetty.version>
+        <dropwizard.version>0.8.0-rc3-SNAPSHOT</dropwizard.version>
     </properties>
 
     <dependencies>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-            <version>17.0</version>
-        </dependency>
 
         <dependency>
             <groupId>io.dropwizard</groupId>
@@ -60,14 +55,14 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.11</version>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
 
         <dependency>
-            <groupId>org.easytesting</groupId>
-            <artifactId>fest-assert-core</artifactId>
-            <version>2.0M10</version>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>1.7.1</version>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/src/test/java/com/bazaarvoice/dropwizard/assets/AssetServletTest.java
+++ b/src/test/java/com/bazaarvoice/dropwizard/assets/AssetServletTest.java
@@ -3,7 +3,6 @@ package com.bazaarvoice.dropwizard.assets;
 import com.google.common.cache.CacheBuilderSpec;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.net.HttpHeaders;
-import org.eclipse.jetty.http.HttpFields;
 import org.eclipse.jetty.http.HttpHeader;
 import org.eclipse.jetty.http.HttpTester;
 import org.eclipse.jetty.http.MimeTypes;
@@ -15,7 +14,8 @@ import org.junit.Test;
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.fest.assertions.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
+
 
 public class AssetServletTest {
     private static final CacheBuilderSpec DEFAULT_CACHE_SPEC = CacheBuilderSpec.parse("maximumSize=100");
@@ -211,15 +211,15 @@ public class AssetServletTest {
         response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
         final long lastModifiedTime = response.getDateField(HttpHeaders.LAST_MODIFIED);
 
-        request.setHeader(HttpHeaders.IF_MODIFIED_SINCE, HttpFields.formatDate(lastModifiedTime));
+        request.putDateField(HttpHeaders.IF_MODIFIED_SINCE, lastModifiedTime);
         response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
         final int statusWithMatchingLastModifiedTime = response.getStatus();
 
-        request.setHeader(HttpHeaders.IF_MODIFIED_SINCE, HttpFields.formatDate(lastModifiedTime - 100));
+        request.putDateField(HttpHeaders.IF_MODIFIED_SINCE, lastModifiedTime - 100);
         response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
         final int statusWithStaleLastModifiedTime = response.getStatus();
 
-        request.setHeader(HttpHeaders.IF_MODIFIED_SINCE, HttpFields.formatDate(lastModifiedTime + 100));
+        request.putDateField(HttpHeaders.IF_MODIFIED_SINCE, lastModifiedTime + 100);
         response = HttpTester.parseResponse(servletTester.getResponses(request.generate()));
         final int statusWithRecentLastModifiedTime = response.getStatus();
 


### PR DESCRIPTION
Updated Dropwizard version to 0.8.0-rc3-SNAPSHOT.
Also made Jetty Servlet, AssertJ and JUnit consistent with current dropwizard versions. 
Removed Guava dependency which is already included as part of Dropwizrad-Core
